### PR TITLE
Add Resampling Support and Command-Line Audio File Argument

### DIFF
--- a/egs/3dspeaker/speaker-diarization/run_audio.sh
+++ b/egs/3dspeaker/speaker-diarization/run_audio.sh
@@ -11,7 +11,27 @@ set -e
 stage=1
 stop_stage=6
 
-wav_list=examples/wav.list
+# Add a command-line argument for the audio file
+audio_file=""
+while getopts "a:" opt; do
+  case $opt in
+    a)
+      audio_file=$OPTARG
+      ;;
+    *)
+      echo "Usage: $0 -a <audio_file>"
+      exit 1
+      ;;
+  esac
+done
+
+if [ -z "$audio_file" ]; then
+  echo "Audio file not specified. Use -a to specify the audio file."
+  exit 1
+fi
+
+# Use the specified audio file
+wav_list=$audio_file
 exp=exp
 conf_file=conf/diar.yaml
 gpus="0 1 2 3"
@@ -26,12 +46,7 @@ rttm_dir=$exp/rttm
 if [ "${stage}" -le 1 ] && [ "${stop_stage}" -ge 1 ]; then
   echo "$(basename $0) Stage 1: Prepare input wavs..."
   mkdir -p examples
-  wget "https://modelscope.cn/api/v1/models/damo/speech_eres2net-large_speaker-diarization_common/repo\
-?Revision=master&FilePath=examples/2speakers_example.wav" -O examples/2speakers_example.wav
-  wget "https://modelscope.cn/api/v1/models/damo/speech_eres2net-large_speaker-diarization_common/repo\
-?Revision=master&FilePath=examples/2speakers_example.rttm" -O examples/2speakers_example.rttm
-  echo "examples/2speakers_example.wav" > examples/wav.list
-  echo "examples/2speakers_example.rttm" > examples/refrttm.list
+  echo "$audio_file" > examples/wav.list
 fi
 
 if [ ${stage} -le 2 ] && [ ${stop_stage} -ge 2 ]; then


### PR DESCRIPTION
This PR introduces the following changes:

Automatic Resampling:

Added support for automatic resampling of input audio files in the main script when the sample rate does not match the expected VAD_PRETRAINED['sample_rate'].
The code now uses torchaudio.transforms.Resample to resample audio files on the fly, preventing errors when users input files with non-matching sample rates.

Command-Line Argument for Audio File:

Updated the shell script to allow the user to specify the audio file directly via a command-line argument (-a <audio_file>).
This change eliminates the need for hardcoded wav.list entries and improves flexibility when running the script on different audio files.